### PR TITLE
tinyfix: read_only long transaction should read distinct tuples

### DIFF
--- a/ermia_takada/frame.cc
+++ b/ermia_takada/frame.cc
@@ -90,11 +90,16 @@ void makeTask(std::vector<Task> &tasks, Xoroshiro128Plus &rnd, FastZipf &zipf)
     tasks.clear();
     if ((rnd.next() % 100) < ronly_ratio)
     {
+        std::set<uint64_t> keys;
         for (size_t i = 0; i < max_ope_readonly; ++i)
         {
-            uint64_t tmpkey;
+            uint64_t tmpkey = zipf() % tuple_num;
             // decide access destination key.
-            tmpkey = zipf() % tuple_num;
+            while (keys.find(tmpkey) != keys.end())
+            {
+                tmpkey = zipf() % tuple_num;
+            }
+            keys.insert(tmpkey);
             tasks.emplace_back(Ope::READ, tmpkey);
         }
     }

--- a/ermia_takada/frame.hh
+++ b/ermia_takada/frame.hh
@@ -11,6 +11,7 @@
 #include <xmmintrin.h>
 #include <chrono>
 #include <algorithm>
+#include <set>
 
 #include "../include/zipf.hh"
 


### PR DESCRIPTION
*Proposal*
```c++
this result is executed by RCL+SSN+Robust Safe Retry
abort_counts_:			9814583
commit_counts_:			1101959
read SSNcheck abort:		2180
write SSNcheck abort:		51
commit SSNcheck abort:		6290
ww conflict abort:		0
total_readonly_abort:		68727
total_read deadlock_abort:	1155530
total_write deadlock_abort:	8650532
abort_rate:			0.8991
1 68727
latency[ns]:			10891.1996
throughput[tps]:		367269
```

*Baseline*
```c++
this result is executed by RCL+SSN
abort_counts_:			3633421
commit_counts_:			1154626
read SSNcheck abort:		2167
write SSNcheck abort:		4
commit SSNcheck abort:		6700
ww conflict abort:		0
total_readonly_abort:		1625566
total_read deadlock_abort:	2480603
total_write deadlock_abort:	1143947
abort_rate:			0.7589
1 15092
5780 1
latency[ns]:			10394.5512
throughput[tps]:		384817

```

@YoichiroTacker Please review.


