### PR TITLE
change `USE_LOCK` flag from compiler definition to environment variable

### DIFF
--- a/ermia_takada/CMakeLists.txt
+++ b/ermia_takada/CMakeLists.txt
@@ -52,5 +52,4 @@ add_definitions(-Drratio=0)                    #read ratio of single transaction
 add_definitions(-Dthread_num=7)                 #Total number of records
 add_definitions(-Dtuple_num=10000)              #Total number of records
 add_definitions(-Dskew=0.5)                     #skew(0~0.99)
-add_definitions(-DUSE_LOCK=1)                   #read-only lock flag "0 = dont use, 1 = use"
 add_definitions(-DDATA_SIZE=20)                #int(4byte)* DATA_SIZE= Data byte

--- a/ermia_takada/frame.cc
+++ b/ermia_takada/frame.cc
@@ -1,6 +1,7 @@
 #include "frame.hh"
 
 using namespace std;
+extern int USE_LOCK;
 
 void Result::displayAllResult()
 {
@@ -311,6 +312,10 @@ void worker(size_t thid, char &ready, const bool &start, const bool &quit)
 
 int main(int argc, char *argv[])
 {
+  auto use_lock = std::getenv("USE_LOCK");
+  if (use_lock) {
+    USE_LOCK = atoi(use_lock);
+  }
     print_mode();
     // displayParameter();
     makeDB();

--- a/ermia_takada/rcl.cc
+++ b/ermia_takada/rcl.cc
@@ -4,6 +4,7 @@ using namespace std;
 
 extern std::atomic<uint64_t> timestampcounter;
 extern std::mutex SsnLock;
+int USE_LOCK = 0;
 
 void print_mode()
 {


### PR DESCRIPTION
After merging this PR, you can switch {baseline/proposal} protocols with environment variable, like the followings:
![image](https://github.com/YoichiroTacker/ccbench/assets/1196079/20eeabe5-74f6-4a53-90ce-0e2518d6e237)

@YoichiroTacker please review.